### PR TITLE
Removing need to add an @ before priority declaration

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
@@ -1,0 +1,25 @@
+# 🏎️ Awesome PR: [Brief Title]
+
+## 🏁 What's this PR doing?
+[Explain the changes in a sentence or two]
+
+## 🛠️ Changes made
+- [Change 1]
+- [Change 2]
+- [Change 3]
+
+## 🏆 Why it's awesome
+[Explain why this change is beneficial]
+
+## 🧪 Testing
+- [ ] Tested manually
+- [ ] Updated unit tests
+- [ ] All CI checks pass
+
+## 📚 Documentation
+- [ ] README updated (if needed)
+- [ ] Comments added/updated
+
+## 🎭 Meme tax
+[Insert a relevant meme or gif here for good vibes]
+

--- a/README.md
+++ b/README.md
@@ -77,9 +77,8 @@ todo-vimst stores your Todoist API token locally using a basic encryption method
 
 ## 🏷️ Priorities and Labels
 
-- Use `#P1`, `#P2`, `#P3`, or `#P4` to set task priority (P1 is highest, P4 is lowest)
-- Any other `#Tag` will be added as a label to your task
-- No priority tag? No problem! It defaults to P4
+- Use `P1`, `P2`, `P3`, or `P4` to set task priority (P1 is highest, P4 is lowest). No priority set? No problem! It defaults to P4
+- Any element `#Tag` will be added as a label to your task
 
 ## 🎭 Examples
 

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ todo-vimst stores your Todoist API token locally using a basic encryption method
 ## 🏷️ Priorities and Labels
 
 - Use `P1`, `P2`, `P3`, or `P4` to set task priority (P1 is highest, P4 is lowest). No priority set? No problem! It defaults to P4
-- Any element `#Tag` will be added as a label to your task
+- Any element `@Label` will be added as a label to your task
 
 ## 🎭 Examples
 

--- a/README.md
+++ b/README.md
@@ -63,10 +63,10 @@ todo-vimst stores your Todoist API token locally using a basic encryption method
 
 2. Start adding TODO comments in your code:
    ```
-   // TODO: Refactor the flux capacitor @P1 @Project:TimeTravel
-   # TODO: Buy plutonium @P2 @Shopping
-   -- TODO: Calibrate speedometer to 88 mph @P3 @Maintenance
-   % TODO: Write memoir: "My Life at 1.21 Gigawatts" @P4 @Personal
+   // TODO: Optimize tire management strategy P1 @RacePrep
+   # TODO: Analyze competitor's lap times P2 @Strategy
+   -- TODO: Calibrate DRS activation points P3 @Setup
+   % TODO: Write post-race report P4 @Admin
    ```
 
 3. Create tasks from your TODOs:
@@ -77,20 +77,20 @@ todo-vimst stores your Todoist API token locally using a basic encryption method
 
 ## 🏷️ Priorities and Labels
 
-- Use `@P1`, `@P2`, `@P3`, or `@P4` to set task priority (P1 is highest, P4 is lowest)
-- Any other `@Tag` will be added as a label to your task
+- Use `#P1`, `#P2`, `#P3`, or `#P4` to set task priority (P1 is highest, P4 is lowest)
+- Any other `#Tag` will be added as a label to your task
 - No priority tag? No problem! It defaults to P4
 
 ## 🎭 Examples
 
 ```python
-# TODO: Implement time circuits @P1 @Feature
+# TODO: Implement traction control system P1 @Feature
 # This will create a high-priority task with the "Feature" label
 
-// TODO: Test flux dispersal @P3 @Testing @BackToTheFuture
-// This creates a medium-priority task with "Testing" and "BackToTheFuture" labels
+// TODO: Test aerodynamics in wind tunnel P3 @Testing @MP4/4
+// This creates a medium-priority task with "Testing" and "MP4/4" labels
 
--- TODO: Document temporal experiments
+-- TODO: Document tire degradation analysis
 -- This creates a low-priority task (default P4) with no labels
 
 '''
@@ -100,7 +100,7 @@ that spans multiple lines
 # This creates a single task with the content "This is a multi-line task that spans multiple lines"
 ```
 
-todo-vimst supports file type-specific comment parsing, ensuring that the correct comment syntax is used for each programming language. It recognizes common file types such as Python, C, Java, JavaScript, Lua, and more.
+todo-vimst now supports file type-specific comment parsing, ensuring that the correct comment syntax is used for each programming language. It recognizes common file types such as Python, C, Java, JavaScript, Lua, and more.
 
 ## 🐛 Troubleshooting
 

--- a/lua/todo-vimst/parser.lua
+++ b/lua/todo-vimst/parser.lua
@@ -78,16 +78,19 @@ local function parse_todo(content)
     }
   }
 
-  -- Extract priority and labels
+  -- Extract labels (still using @)
   content = content:gsub("@(%S+)", function(tag)
-    if PRIORITY_MAP[tag] then
-      task.priority = PRIORITY_MAP[tag]
-      task.metadata.priority = tag
-    else
-      table.insert(task.labels, tag)
-      table.insert(task.metadata.labels, tag)
-    end
+    table.insert(task.labels, tag)
+    table.insert(task.metadata.labels, tag)
     return ""
+  end)
+
+  -- Extract priority (without @)
+  content = content:gsub("%s*([Pp][1234])%s*", function(priority)
+    local priority_upper = priority:upper()
+    task.priority = PRIORITY_MAP[priority_upper]
+    task.metadata.priority = priority_upper
+    return " "  -- Replace with a space to avoid words sticking together
   end)
 
   -- Clean up the todo text

--- a/lua/todo-vimst/parser.lua
+++ b/lua/todo-vimst/parser.lua
@@ -78,14 +78,14 @@ local function parse_todo(content)
     }
   }
 
-  -- Extract labels (still using @)
+  -- Extract labels
   content = content:gsub("@(%S+)", function(tag)
     table.insert(task.labels, tag)
     table.insert(task.metadata.labels, tag)
     return ""
   end)
 
-  -- Extract priority (without @)
+  -- Extract priority
   content = content:gsub("%s*([Pp][1234])%s*", function(priority)
     local priority_upper = priority:upper()
     task.priority = PRIORITY_MAP[priority_upper]


### PR DESCRIPTION
# 🏎️ Awesome PR: Priority Parsing Without @ Symbol

## 🏁 What's this PR doing?
This PR updates the priority parsing to recognize P1/P2/P3/P4 without requiring the @ symbol, aligning more closely with Todoist's native behavior.

## 🛠️ Changes made
- Modified `parse_todo` function in `lua/todo-vimst/parser.lua`
- Priority markers (P1, P2, P3, P4) now recognized without @ symbol
- Priorities are case-insensitive
- Priorities are removed from the final task content

## 🏆 Why it's awesome
This change makes the plugin more intuitive and aligns with Todoist's default behavior, improving user experience.

## 🧪 Testing
- [ ] Tested manually with various input formats
- [ ] Updated unit tests (if applicable)
- [ ] All CI checks pass

## 📚 Documentation
- [ ] README updated to reflect new priority parsing behavior
- [ ] Comments added/updated in `parser.lua`

## 🎭 Meme tax
[![image](https://github.com/user-attachments/assets/c483b9dc-178b-4312-b4cb-979e07e61fc7)](https://media.tenor.com/rTK3VUKyuvoAAAAM/f1-alonso.gif)
